### PR TITLE
strict validation in UnbindFS

### DIFF
--- a/naming/cpe_name_unbinder.go
+++ b/naming/cpe_name_unbinder.go
@@ -82,38 +82,41 @@ func UnbindFS(fs string) (common.WellFormedName, error) {
 		// Set the value of the corresponding attribute.
 		switch a {
 		case 2:
-			result.Set(common.AttributePart, v)
+			err = result.Set(common.AttributePart, v)
 			break
 		case 3:
-			result.Set(common.AttributeVendor, v)
+			err = result.Set(common.AttributeVendor, v)
 			break
 		case 4:
-			result.Set(common.AttributeProduct, v)
+			err = result.Set(common.AttributeProduct, v)
 			break
 		case 5:
-			result.Set(common.AttributeVersion, v)
+			err = result.Set(common.AttributeVersion, v)
 			break
 		case 6:
-			result.Set(common.AttributeUpdate, v)
+			err = result.Set(common.AttributeUpdate, v)
 			break
 		case 7:
-			result.Set(common.AttributeEdition, v)
+			err = result.Set(common.AttributeEdition, v)
 			break
 		case 8:
-			result.Set(common.AttributeLanguage, v)
+			err = result.Set(common.AttributeLanguage, v)
 			break
 		case 9:
-			result.Set(common.AttributeSwEdition, v)
+			err = result.Set(common.AttributeSwEdition, v)
 			break
 		case 10:
-			result.Set(common.AttributeTargetSw, v)
+			err = result.Set(common.AttributeTargetSw, v)
 			break
 		case 11:
-			result.Set(common.AttributeTargetHw, v)
+			err = result.Set(common.AttributeTargetHw, v)
 			break
 		case 12:
-			result.Set(common.AttributeOther, v)
+			err = result.Set(common.AttributeOther, v)
 			break
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 	return result, nil

--- a/naming/cpe_name_unbinder_test.go
+++ b/naming/cpe_name_unbinder_test.go
@@ -120,6 +120,9 @@ func TestUnbindURI(t *testing.T) {
 	}, {
 		s:       "cpe:/a:b*c",
 		wantErr: common.ErrParse,
+	}, {
+		s:       "cpe:/z:%01%01microsoft",
+		wantErr: common.ErrParse,
 	},
 	}
 
@@ -228,6 +231,10 @@ func TestUnbindFS(t *testing.T) {
 	}, {
 		// embedded unquoted ?
 		s:       `cpe:2.3:a:2g?lux:com_sexypolling:0.9.1:-:-:*:-:joomla\!:*:*`,
+		wantErr: common.ErrParse,
+	}, {
+		// invalid  part
+		s:       `cpe:2.3:z:2glux*:??com_sexypolling??:0.9.1:-:-:*:-:joomla\!:*:*`,
 		wantErr: common.ErrParse,
 	},
 	}

--- a/naming/cpe_name_unbinder_test.go
+++ b/naming/cpe_name_unbinder_test.go
@@ -123,6 +123,10 @@ func TestUnbindURI(t *testing.T) {
 	}, {
 		s:       "cpe:/z:%01%01microsoft",
 		wantErr: common.ErrParse,
+	}, {
+		// empty part
+		s:       ` cpe:/:microsoft`,
+		wantErr: common.ErrParse,
 	},
 	}
 
@@ -235,6 +239,10 @@ func TestUnbindFS(t *testing.T) {
 	}, {
 		// invalid  part
 		s:       `cpe:2.3:z:2glux*:??com_sexypolling??:0.9.1:-:-:*:-:joomla\!:*:*`,
+		wantErr: common.ErrParse,
+	}, {
+		// empty part
+		s:       `cpe:2.3::2glux*:??com_sexypolling??:0.9.1:-:-:*:-:joomla\!:*:*`,
 		wantErr: common.ErrParse,
 	},
 	}


### PR DESCRIPTION
Fixed to return an error when unbindFS is performed on a cpe with an invalid cpe part.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
