### PR TITLE
Add method to retrieve raw value representation from a WFN

### DIFF
--- a/common/logical_value.go
+++ b/common/logical_value.go
@@ -49,3 +49,12 @@ func (lv LogicalValue) String() string {
 	}
 	return "NA"
 }
+
+// Raw returns the raw string representation of the logical value.
+func (lv LogicalValue) Raw() string {
+	if lv.Any {
+		return "*"
+	}
+
+	return "-"
+}

--- a/common/value.go
+++ b/common/value.go
@@ -1,0 +1,12 @@
+package common
+
+// Value represents a
+type Value struct {
+	Quoted string
+	Raw    string
+}
+
+// String always return the quoted value representation.
+func (v Value) String() string {
+	return v.Quoted
+}

--- a/common/value.go
+++ b/common/value.go
@@ -1,12 +1,12 @@
 package common
 
-// Value represents a
+// Value represents a value in raw and quoted form.
 type Value struct {
 	Quoted string
 	Raw    string
 }
 
-// String always return the quoted value representation.
+// String always returns the quoted value representation.
 func (v Value) String() string {
 	return v.Quoted
 }

--- a/common/well_formed_name.go
+++ b/common/well_formed_name.go
@@ -90,8 +90,8 @@ func (wfn WellFormedName) Get(attribute string) interface{} {
 	}
 }
 
-// GetRaw returns the raw string representation of the given attribute.
-func (wfn WellFormedName) GetRaw(attribute string) interface{} {
+// GetRaw returns the raw string representation of the given attribute. Defaults to "*" (ANY).
+func (wfn WellFormedName) GetRaw(attribute string) string {
 	v := wfn.get(attribute)
 	switch v := v.(type) {
 	case Value:
@@ -99,7 +99,7 @@ func (wfn WellFormedName) GetRaw(attribute string) interface{} {
 	case LogicalValue:
 		return v.Raw()
 	default:
-		return v
+		return "*"
 	}
 }
 

--- a/naming/cpe_name_unbinder.go
+++ b/naming/cpe_name_unbinder.go
@@ -189,7 +189,7 @@ func unbindValueFS(s string) (_ interface{}, err error) {
 	}
 
 	v := common.Value{
-		Raw: s,
+		Raw: decodeFS(s),
 	}
 
 	v.Quoted, err = addQuoting(s)
@@ -400,6 +400,27 @@ func decode(s string) (interface{}, error) {
 		embedded = true
 	}
 	return result, nil
+}
+
+// decodeFS decodes a FS part so that it resembles the pre-quoting part text.
+// In other words: what you would get by percent-decoding the URI bound equivalent.
+func decodeFS(s string) (v string) {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			switch {
+			case i < len(s)-1:
+				v += string(s[i+1])
+				i += 1
+			default:
+				v += string(s[i])
+			}
+		default:
+			v += string(s[i])
+		}
+	}
+
+	return v
 }
 
 // unpack unpacks the elements in s and sets the attributes in the given

--- a/naming/cpe_name_unbinder.go
+++ b/naming/cpe_name_unbinder.go
@@ -200,8 +200,16 @@ func unbindValueFS(s string) (_ interface{}, err error) {
 	return v, nil
 }
 
-// EscapeFS escapes a string so that it can be used within a formatted string.
+// EscapeFS escapes a string so that it can be directly used within a formatted string.
+// Logical values are untouched. Empty strings default to "*" (ANY).
 func EscapeFS(s string) (v string) {
+	switch s {
+	case "*", "-":
+		return s
+	case "":
+		return "*"
+	}
+
 	for i := 0; i < len(s); i++ {
 		switch c := string(s[i]); {
 		case common.IsAlphanum(c):

--- a/naming/cpe_name_unbinder.go
+++ b/naming/cpe_name_unbinder.go
@@ -178,7 +178,7 @@ func getCompFS(fs string, i int) string {
 // @param s value to be unbound
 // @return logical value or quoted string
 // @throws ParseException
-func unbindValueFS(s string) (interface{}, error) {
+func unbindValueFS(s string) (_ interface{}, err error) {
 	if s == "*" {
 		any, _ := common.NewLogicalValue("ANY")
 		return any, nil
@@ -187,11 +187,17 @@ func unbindValueFS(s string) (interface{}, error) {
 		na, _ := common.NewLogicalValue("NA")
 		return na, nil
 	}
-	result, err := addQuoting(s)
+
+	v := common.Value{
+		Raw: s,
+	}
+
+	v.Quoted, err = addQuoting(s)
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+
+	return v, nil
 }
 
 // Inspect each character in a string, copying quoted characters, with

--- a/naming/cpe_name_unbinder.go
+++ b/naming/cpe_name_unbinder.go
@@ -200,6 +200,22 @@ func unbindValueFS(s string) (_ interface{}, err error) {
 	return v, nil
 }
 
+// EscapeFS escapes a string so that it can be used within a formatted string.
+func EscapeFS(s string) (v string) {
+	for i := 0; i < len(s); i++ {
+		switch c := string(s[i]); {
+		case common.IsAlphanum(c):
+			v += c
+		case c == ".", c == "-", c == "_":
+			v += c
+		default:
+			v += "\\" + c
+		}
+	}
+
+	return v
+}
+
 // Inspect each character in a string, copying quoted characters, with
 // their escaping, into the result.  Look for unquoted non alphanumerics
 // and if not "*" or "?", add escaping.


### PR DESCRIPTION
This PR adds the ability to retrieve the raw string representation of a CPE part. This was previously impossible since this module offers no way to unquote parts and never exposes the original value in some way. All tests for this PR pass and all changes should be fully backwards-compatible.